### PR TITLE
Send results:empty event without requiring the empty_content option to b...

### DIFF
--- a/src/coffee/widget.coffee
+++ b/src/coffee/widget.coffee
@@ -247,7 +247,9 @@ class NeatComplete.Widget extends NeatComplete.Dispatch
         @output.appendChild(@_renderEmpty())
         @_displayResults()
         @trigger "results:empty"
-      else @_hideResults()
+      else
+        @_hideResults()
+        @trigger "results:empty"
 
       @trigger "results:update"
     return


### PR DESCRIPTION
Send results:empty event without requiring the empty_content option to be supplied

attention @campreb 